### PR TITLE
feat: embed program from first pass

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    "harness-cdk", 
+    "harness-cdk",
     "harness-macros",
     "harness-node",
     "harness-primitives",

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# harness
 <div align="center">
 	<img width="256" src="assets/magneto-bw.svg" alt="Harness logo">
 
 # Harness
+
 </div>
 
 This framework allows for an IC canister to be piggybacked on IoT devices for:
@@ -11,12 +11,13 @@ This framework allows for an IC canister to be piggybacked on IoT devices for:
 - to provide a bridge between the IoT device and the IC.
 
 ## TODO
+
 - [ ] Node implementations
 - [ ] CDK implementation
 - [x] Macros base implementation
 - [ ] Test examples
 - [ ] Running harness on chain
- 
+
 ## Release notes
 
 Release notes and unreleased changes can be found in the [CHANGELOG](./CHANGELOG.md).

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# HARNESS_DIR: the directory where the harness code is located
+
+HARNESS_PROJ="${HARNESS_DIR:-./Cargo.toml}"
+
+cargo build --manifest-path $HARNESS_PROJ --features harness-cdk/__harness-build --target wasm32-unknown-unknown --release
+cp $TARGET/wasm32-unknown-unknown/release/hello_backend.wasm ./assets/

--- a/harness-cdk/Cargo.toml
+++ b/harness-cdk/Cargo.toml
@@ -10,6 +10,10 @@ name = "compilation_tests"
 path = "compilation_tests/all.rs"
 required-features = ["harness-macros/__harness-build"]
 
+[[test]]
+name = "embed_program"
+path = "macro_tests/embed_program.rs"
+
 [dependencies]
 thiserror = "1.0"
 anyhow = "1.0.81"

--- a/harness-cdk/compilation_tests/all.rs
+++ b/harness-cdk/compilation_tests/all.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "__harness-build")]
+
 #[rustversion::stable]
 #[test]
 fn compilation_tests() {

--- a/harness-cdk/macro_tests/embed_program.rs
+++ b/harness-cdk/macro_tests/embed_program.rs
@@ -1,0 +1,20 @@
+use std::io::prelude::*;
+
+use harness_macros::get_program;
+use harness_primitives::{program::Program, HARNESS_PATH};
+
+#[test]
+fn test_embed_program() {
+    if !std::path::Path::new(HARNESS_PATH)
+        .join("harness_code.wasm")
+        .exists()
+    {
+        return; // skip the test
+    }
+
+    // should be able to compile the program to memory and populate the program struct
+    let program = get_program!();
+
+    // better testing and more dynamic paths for builds
+    assert!(!program.id.is_empty())
+}

--- a/harness-cdk/src/arbiter.rs
+++ b/harness-cdk/src/arbiter.rs
@@ -1,30 +1,38 @@
+#!(cfg(not(feature = "__harness-build")))
+
+//! This is is where the harness program is loaded at compile time, we create the arbiter to arbiter operations of the harness program.
+
 use std::cell::RefCell;
+use std::io::prelude::*;
 
 use candid::Nat;
 use ic_cdk::{api::management_canister::http_request::HttpResponse, query};
 
 use crate::device::Device;
 
-//use harness_macros::get_harness_schema;
-
 use harness_primitives::{
     http::{get_header, Header, Method, Request},
     program::Program,
 };
 
-// FIXME: placeholder
-const HARNESS_WASM: &[u8] =
-    include_bytes!("../../examples/hello/target/wasm32-unknown-unknown/release/hello_backend.wasm");
-
 pub(crate) struct Arbiter {
     devices: Vec<Device>,
-    programs: Vec<Program>,
+    program: Program,
 }
 
 impl Arbiter {
-    fn new() -> Self {
-        // let schema = { get_harness_schema!() };
-        todo!()
+    pub(crate) fn new() -> Result<Self, String> {
+        // read the harness code bytes to memory at compile time
+        let program = harness_macros::get_program!();
+
+        Ok(Self {
+            devices: Vec::new(),
+            program,
+        })
+    }
+
+    pub(crate) fn add_device(&mut self, device: Device) {
+        self.devices.push(device);
     }
 }
 
@@ -54,7 +62,7 @@ fn http_request(req: Request) -> HttpResponse {
                     return HttpResponse {
                         status: Nat::from(200u16),
                         headers: vec![],
-                        body: HARNESS_WASM.to_vec(),
+                        body: vec![], //HARNESS_WASM.to_vec(),
                     };
                 }
                 None => {

--- a/harness-cdk/src/arbiter.rs
+++ b/harness-cdk/src/arbiter.rs
@@ -5,7 +5,8 @@ use ic_cdk::{api::management_canister::http_request::HttpResponse, query};
 
 use crate::device::Device;
 
-use harness_macros::get_harness_schema;
+//use harness_macros::get_harness_schema;
+
 use harness_primitives::{
     http::{get_header, Header, Method, Request},
     program::Program,
@@ -22,13 +23,13 @@ pub(crate) struct Arbiter {
 
 impl Arbiter {
     fn new() -> Self {
-        // get_harness_schema!();
+        // let schema = { get_harness_schema!() };
         todo!()
     }
 }
 
 thread_local! {
-    static Devices: RefCell<Vec<Device>> = RefCell::new(Vec::new());
+    static DEVICES: RefCell<Vec<Device>> = RefCell::new(Vec::new());
 }
 
 #[query]
@@ -40,7 +41,7 @@ fn http_request(req: Request) -> HttpResponse {
             // register the device with the arbiter
             match get_header(&Header::HarnessNodeUrl.to_string(), &req.headers) {
                 Some(url) => {
-                    Devices.with(|devices| {
+                    DEVICES.with(|devices| {
                         devices.borrow_mut().push(Device {
                             id: ic_cdk::api::caller(),
                             url,

--- a/harness-cdk/src/device.rs
+++ b/harness-cdk/src/device.rs
@@ -4,7 +4,7 @@
 use std::borrow::Cow;
 
 use candid::{CandidType, Decode, Deserialize, Encode, Principal};
-use harness_primitives::ProgramId;
+use harness_primitives::program::ProgramId;
 use ic_stable_structures::{storable::Bound, Storable};
 use serde::Serialize;
 

--- a/harness-cdk/tests/harness_impl.rs
+++ b/harness-cdk/tests/harness_impl.rs
@@ -39,6 +39,12 @@ fn simple_function_test_no_return() {
         println!("Hi, {name}");
     }
 
+    #[harness]
+    fn hello(name: String) -> String {
+        println!("Hello, {name}");
+        return String::new();
+    }
+
     harness_cdk::harness_export!();
 
     let schema = { harness_macros::get_harness_schema!() };

--- a/harness-cdk/tests/harness_impl.rs
+++ b/harness-cdk/tests/harness_impl.rs
@@ -15,20 +15,22 @@ fn candid_serde() {
     assert_eq!(original_val, val);
 }
 
-#[test]
-fn simple_function_test() {
-    #[harness(strip = ["something", "else"])]
-    #[query]
-    fn hello(msg: String) -> String {
-        format!("Hello, {msg}!")
-    }
+// #[test]
+// fn simple_function_test() {
+//     #[harness(strip = ["something", "else"])]
+//     #[query]
+//     fn hello(msg: String) -> String {
+//         format!("Hello, {msg}!")
+//     }
 
-    let res = __harness_hello(&Encode!(&String::from("World")).unwrap()).unwrap();
-    assert_eq!(
-        Decode!(&res, String).unwrap(),
-        String::from("Hello, World!")
-    );
-}
+//     harness_cdk::harness_export!();
+
+//     let res = __harness_hello(&Encode!(&String::from("World")).unwrap()).unwrap();
+//     assert_eq!(
+//         Decode!(&res, String).unwrap(),
+//         String::from("Hello, World!")
+//     );
+// }
 
 #[test]
 fn simple_function_test_no_return() {
@@ -36,6 +38,10 @@ fn simple_function_test_no_return() {
     fn hi(name: String) {
         println!("Hi, {name}");
     }
+
+    harness_cdk::harness_export!();
+
+    let schema = { harness_macros::get_harness_schema!() };
 
     let res = __harness_hi(&Encode!(&String::from("stranger")).unwrap()).unwrap();
     assert!(res.is_empty());

--- a/harness-macros/build.rs
+++ b/harness-macros/build.rs
@@ -1,0 +1,20 @@
+fn main() {
+    let path = {
+        if cfg!(unix) {
+            // `~/.config/MyApp` for unix systems
+            format!("{}/.config/harness", std::env::var("HOME").unwrap())
+        } else if cfg!(windows) {
+            // `%USERPROFILE%\AppData\Local\MyApp\` for windows
+            format!(
+                "{}\\AppData\\Local\\harness",
+                std::env::var("USERPROFILE").unwrap()
+            )
+        } else {
+            panic!("Unsupported OS. Please open an issue on the repo to add support for this OS")
+        }
+    };
+
+    if !std::path::Path::new(&path).exists() {
+        std::fs::create_dir_all(&path).unwrap();
+    }
+}

--- a/harness-macros/src/lib.rs
+++ b/harness-macros/src/lib.rs
@@ -1,18 +1,16 @@
 //! This crate provides the `harness` and `harness_export` macros.
 
+use std::{io::prelude::*, io::BufReader, sync::Mutex};
+
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::{quote, ToTokens};
-
-use std::{io::BufReader, sync::Mutex};
 use syn::{Error, ItemFn, Signature, Type};
 
 use harness_primitives::{
-    get_harness_path,
+    ensure_path_created,
     internals::{IntermediateSchema, Schema, Service},
 };
-
-//use harness_primitives::schema::{Method, Schema};
 
 mod bootstrap;
 
@@ -146,8 +144,8 @@ pub fn harness_export(input: TokenStream) -> TokenStream {
         .collect::<Vec<_>>();
 
     let schema = HARNESS_SCHEMA.lock().unwrap().clone();
-    let path = match get_harness_path() {
-        Ok(path) => path,
+    let path = match ensure_path_created() {
+        Ok(path) => path.to_string(),
         Err(e) => {
             return syn::Error::new(Span::call_site(), e)
                 .to_compile_error()
@@ -155,6 +153,7 @@ pub fn harness_export(input: TokenStream) -> TokenStream {
         }
     };
 
+    // fixme: this assumes that at any one time, there is only one harness program being built, disambiguate for different programs
     if let Err(err) = std::fs::write(
         path + "/harness_schema.json",
         serde_json::to_string(&schema).unwrap(),
@@ -239,27 +238,8 @@ fn create_harness_function(func: ItemFn) -> syn::Result<TokenStream> {
     }
 
     if let Ok(mut schema) = HARNESS_SCHEMA.lock() {
-        let args = arg_types
-            .iter()
-            .map(|t| {
-                quote! {
-                    let mut env = ::candid::types::internal::TypeContainer::new();
-                    env.add::<#t>().to_string()
-                }
-                .to_string()
-            })
-            .collect();
-        let rets = ret_types
-            .iter()
-            .map(|t| {
-                quote! {
-                    let mut env = ::candid::types::internal::TypeContainer::new();
-                    env.add::<#t>().to_string()
-                }
-                .to_string()
-            })
-            .collect();
-
+        let args = arg_types.iter().map(|t| quote!(#t).to_string()).collect();
+        let rets = ret_types.iter().map(|t| quote!(#t).to_string()).collect();
         schema.services.push(Service {
             name: base_name,
             args,
@@ -294,11 +274,12 @@ fn get_args(sig: &Signature) -> syn::Result<(Vec<Type>, Vec<Type>)> {
     Ok((args, rets))
 }
 
-/// This macro is responsible for populating the harness schema to be referenced in our canister.
+/// This macro allows retrieval of the compiled harness program to memory at compile time.
 #[proc_macro]
-pub fn get_harness_schema(_: TokenStream) -> TokenStream {
-    let path = match get_harness_path() {
-        Ok(path) => path,
+pub fn get_program(_item: TokenStream) -> TokenStream {
+    // get harness program compiled code
+    let harness_path = match ensure_path_created() {
+        Ok(path) => std::path::Path::new(path),
         Err(e) => {
             return syn::Error::new(Span::call_site(), e)
                 .to_compile_error()
@@ -306,7 +287,73 @@ pub fn get_harness_schema(_: TokenStream) -> TokenStream {
         }
     };
 
-    let schema_file = match std::fs::File::open(path + "/harness_schema.json") {
+    // fixme: assumption that the generated wasm file is at `{HARNESS_PATH}/harness_code.wasm`
+    let wasm_file_path = harness_path
+        .join("harness_code.wasm")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // only doing fs reads at compile time
+    let mut f = match std::fs::File::open(&wasm_file_path) {
+        Ok(val) => val,
+        Err(err) => {
+            if cfg!(feature = "__harness-build") {
+                return syn::Error::new(Span::call_site(), "wasm file not found, please call after the first build with `--features __harness-build`")
+                    .to_compile_error()
+                    .into();
+            }
+
+            return syn::Error::new(Span::call_site(), format!("wasm file not found: {}", err))
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    let mut buffer = Vec::new();
+    f.read_to_end(&mut buffer)
+        .expect("file read to succeed; qed");
+
+    // fixme: how reliable is metadata for exact file size?
+    let bytes = match std::fs::metadata(&wasm_file_path) {
+        Ok(val) => val.len() as usize,
+        Err(e) => {
+            return syn::Error::new(Span::call_site(), e)
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    let schema = get_schema(&harness_path);
+    TokenStream::from(quote! {
+       {
+        let mut buff = std::io::Cursor::new(vec![0u8; #bytes]);
+        buff.read_exact(&mut vec![#(#buffer),*]).expect("buffer read to succeed; qed");
+
+        // were sure about the size of the buffer
+        let wasm = unsafe {
+            &*(buff.into_inner().as_slice().as_ptr() as *const [u8; #bytes])
+        };
+
+        ::harness_primitives::program::Program {
+            id: #schema.program.expect("program value expected").parse().unwrap(), // fixme: allow
+            schema: #schema,
+            wasm,
+        }
+       }
+    })
+}
+
+/// Allows us to retrieve the schema generated for the harness program.
+fn get_schema(harness_path: &std::path::Path) -> proc_macro2::TokenStream {
+    // fixme: assumption that the schema file is at `{HARNESS_PATH}/harness_schema.json`
+    let schema_file_path = harness_path
+        .join("harness_schema.json")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let schema_file = match std::fs::File::open(&schema_file_path) {
         Ok(val) => val,
         Err(err) => {
             if cfg!(feature = "__harness-build") {
@@ -321,34 +368,70 @@ pub fn get_harness_schema(_: TokenStream) -> TokenStream {
         }
     };
 
-    // HARNESS_SCHEMA is populated on build time
     let schema: Schema = serde_json::from_reader(BufReader::new(schema_file))
         .expect("schema file is not valid json");
 
     let inter_schema = IntermediateSchema::from(schema);
 
-    let version = inter_schema.version;
-    let name = inter_schema.program;
     let mut services = Vec::new();
-    for service in inter_schema.services {
-        let name = service.name;
-        let args = service.args;
-        let rets = service.rets;
+    for mut service in inter_schema.services {
+        service.args.iter_mut().for_each(|arg| {
+            to_candid_type(arg);
+        });
+        to_candid_type(&mut service.rets);
 
+        let name = service.name;
+        let rets = service.rets;
+        let args = service.args;
         services.push(quote! {
-            Service {
-                name: #name,
+            ::harness_primitives::internals::Service {
+                name: String::from(#name),
                 args: vec![#(#args),*],
                 rets: #rets,
             }
         });
     }
 
-    TokenStream::from(quote! {
-        Schema {
-            name: #name,
+    let version = {
+        if let Some(val) = inter_schema.version {
+            quote!(Some(String::from(#val)))
+        } else {
+            quote!(None)
+        }
+    };
+
+    let program = {
+        if let Some(val) = inter_schema.program {
+            quote!(Some(String::from(#val)))
+        } else {
+            quote!(None)
+        }
+    };
+
+    quote! {
+        ::harness_primitives::internals::Schema {
+            program: #program,
             version: #version,
             services: vec![#(#services),*],
         }
-    })
+    }
+}
+
+fn to_candid_type(ty: &mut proc_macro2::TokenStream) {
+    match ty.is_empty() {
+        true => {
+            *ty = quote! {
+                ::candid::types::internal::TypeContainer::new().add::<()>().to_string()
+            }
+        }
+        false => {
+            *ty = {
+                // parse ty as a syn::Type
+                let _ty = syn::parse2::<Type>(ty.clone()).expect("failed to parse type");
+                quote! {
+                    ::candid::types::internal::TypeContainer::new().add::<#ty>().to_string()
+                }
+            }
+        }
+    }
 }

--- a/harness-primitives/Cargo.toml
+++ b/harness-primitives/Cargo.toml
@@ -17,6 +17,7 @@ wapc = "1.1.0"
 wasmtime-provider = "1.16.0"
 candid_parser = "0.1.4"
 candid = "0.10.8"
+const_format = "0.2.32"
 
 [features]
 unstable = []

--- a/harness-primitives/src/harness_os.rs
+++ b/harness-primitives/src/harness_os.rs
@@ -1,11 +1,10 @@
 //! The Harness OS is the system that manages harness programs on the device. It is responsible for loading, unloading, and executing programs.
 use std::collections::HashMap;
-use std::str::FromStr;
 
-use candid::CandidType;
 use wapc::WapcHost;
 
 use crate::error::{Error, Result};
+use crate::program::ProgramId;
 
 /// Holds all the harness programs that have been loaded to the device.
 ///
@@ -74,37 +73,5 @@ impl HarnessOs {
     /// Removes a program from the set, noop if not found.
     pub fn remove_program(&mut self, program_id: &ProgramId) {
         let _ = self.0.remove(program_id);
-    }
-}
-
-/// The program identifier. It should be a human-readable identifier on the Harness network.
-/// TODO: parse? `<network>.<account_id>.<program_name>`
-#[derive(
-    Eq,
-    Ord,
-    Hash,
-    Clone,
-    Debug,
-    PartialEq,
-    PartialOrd,
-    CandidType,
-    candid::Deserialize,
-    serde::Serialize,
-)]
-pub struct ProgramId(Box<str>);
-
-impl TryFrom<String> for ProgramId {
-    type Error = Error;
-
-    fn try_from(program_id: String) -> std::result::Result<Self, Self::Error> {
-        Ok(Self(program_id.into_boxed_str()))
-    }
-}
-
-impl FromStr for ProgramId {
-    type Err = Error;
-
-    fn from_str(program_id: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(Self(program_id.into()))
     }
 }

--- a/harness-primitives/src/internals.rs
+++ b/harness-primitives/src/internals.rs
@@ -1,10 +1,10 @@
-//! This module contains the internal data structures used by the harness sdk.
+//! This module contains the internal data structures used by the harness sdk, and are not intended to be used directly by the crate consumer.
 use proc_macro2::TokenStream;
 
 /// This is the schema for a harness program, it is not intended to be used directly by the crate
 /// consumer, but rather by the `harness` macro to generate the necessary code.
 ///
-/// Ok to access once it's present in the [`Program`](crate::Program) struct.
+/// Ok to access once it's present in the [`Program`](crate::program::Program) struct.
 #[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct Schema {
     pub version: Option<String>,
@@ -49,7 +49,7 @@ impl From<Schema> for IntermediateSchema {
 /// This is the schema for a harness service, it is not intended to be used directly by the crate
 /// consumer, but rather by the `harness` macro to generate the necessary code.
 ///
-/// Ok to access once it's present in the [`Program`](crate::Program) struct.
+/// Ok to access once it's present in the [`Program`](crate::program::Program) struct.
 #[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct Service {
     pub name: String,

--- a/harness-primitives/src/lib.rs
+++ b/harness-primitives/src/lib.rs
@@ -6,3 +6,31 @@ pub mod internals;
 pub mod program;
 
 pub use harness_os::{HarnessOs, ProgramId};
+
+/// Way easier to have a static path in our system that holds all files
+/// that we need to run the harness system instead of having to pass env variable for this.
+pub fn get_harness_path() -> error::Result<String> {
+    let path = {
+        if cfg!(unix) {
+            // `~/.config/MyApp` for unix systems
+            format!("{}/.config/harness", std::env::var("HOME").unwrap())
+        } else if cfg!(windows) {
+            // `%USERPROFILE%\AppData\Local\MyApp\` for windows
+            format!(
+                "{}\\AppData\\Local\\harness",
+                std::env::var("USERPROFILE").unwrap()
+            )
+        } else {
+            return Err(error::Error::internal::<anyhow::Error>(
+                "Unsupported OS. Please open an issue on the repo to add support for this OS",
+                None,
+            ));
+        }
+    };
+
+    if !std::path::Path::new(&path).exists() {
+        std::fs::create_dir_all(&path).unwrap();
+    }
+
+    Ok(path)
+}

--- a/harness-primitives/src/program.rs
+++ b/harness-primitives/src/program.rs
@@ -1,6 +1,42 @@
+use std::str::FromStr;
+
+use crate::error::Error;
+
 /// This struct represents a program that can be loaded into the device.
 pub struct Program {
-    pub id: crate::ProgramId,
+    pub id: ProgramId,
     pub wasm: &'static [u8],
     pub schema: crate::internals::Schema,
+}
+
+/// The program identifier. It should be a human-readable identifier on the Harness network.
+/// TODO: parse? `<network>.<account_id>.<program_name>`
+#[derive(
+    Eq,
+    Ord,
+    Hash,
+    Clone,
+    Debug,
+    PartialEq,
+    PartialOrd,
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+)]
+pub struct ProgramId(Box<str>);
+
+impl TryFrom<String> for ProgramId {
+    type Error = Error;
+
+    fn try_from(program_id: String) -> std::result::Result<Self, Self::Error> {
+        Ok(Self(program_id.into_boxed_str()))
+    }
+}
+
+impl FromStr for ProgramId {
+    type Err = Error;
+
+    fn from_str(program_id: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(Self(program_id.into()))
+    }
 }


### PR DESCRIPTION
We are now able to embed the harness program compiled in memory to the canister code. This is inclusive of both code and generated schema for the harness application.